### PR TITLE
Remove hardcoded uid 1000

### DIFF
--- a/podenv/env.py
+++ b/podenv/env.py
@@ -210,8 +210,8 @@ def rootCap(active: bool, ctx: ExecContext, _: Env) -> None:
         ctx.xdgDir = Path("/run/user/0")
     else:
         ctx.home = Path("/home/user")
-        ctx.xdgDir = Path("/run/user/1000")
-        ctx.args("--user", "1000")
+        ctx.xdgDir = Path("/run/user/{uid}".format(uid=os.geteuid()))
+        ctx.args("--user", "{uid}".format(uid=os.geteuid()))
     ctx.environ["XDG_RUNTIME_DIR"] = str(ctx.xdgDir)
     ctx.environ["HOME"] = str(ctx.home)
 

--- a/podenv/pod.py
+++ b/podenv/pod.py
@@ -189,8 +189,9 @@ class ContainerImage(Runtime):
         with buildah(self.fromRef) as buildId:
             systemType = self.getSystemType(buildId)
             for command in ["useradd -u 1000 -m user",
-                            "mkdir -p /run/user/1000",
-                            "chown 1000:1000 /run/user/1000",
+                            "mkdir -p /run/user/{uid}".format(uid=os.geteuid()),
+                            "chown {uid}:{uid} /run/user/{uid}".format(
+                                uid=os.geteuid()),
                             "mkdir -p /run/user/0",
                             "chown 0:0 /run/user/0"]:
                 buildahRun(buildId, command)


### PR DESCRIPTION
This patch fixes issue when current uid is not 1000.

...
  File "/usr/lib64/python3.7/pathlib.py", line 1251, in mkdir
    self._accessor.mkdir(self, mode)
PermissionError: [Errno 13] Permission denied: '/run/user/1000'