### PR TITLE
Add port publish option

### DIFF
--- a/podenv/env.py
+++ b/podenv/env.py
@@ -197,6 +197,8 @@ class Env:
         doc="Container home path mount"))
     shmsize: str = field(default="", metadata=dict(
         doc="The shm-size value string"))
+    ports: List[str] = field(default_factory=list, metadata=dict(
+        doc="List of port to expose on the host"))
 
     # Internal attribute
     runtime: Optional[Runtime] = field(default=None, metadata=dict(
@@ -501,6 +503,9 @@ def prepareEnv(env: Env, cliArgs: List[str]) -> Tuple[str, ExecArgs, ExecArgs]:
         args.append(f"--shm-size={env.shmsize}")
     if env.home:
         env.ctx.mounts[env.ctx.home] = Path(env.home).expanduser().resolve()
+    if env.ports:
+        for port in env.ports:
+            args.append(f"--publish={port}")
 
     env.ctx.syscaps.extend(env.syscaps)
     env.ctx.environ.update(env.environ)


### PR DESCRIPTION
This patch also add the port publish option
in environment definition.

The sshServer environment must be improved
to let the user set a home + authorized pub key.