### PR TITLE
Fix setupVolumes when name key is 'Name' instead of expected 'name'

### DIFF
--- a/default.podenv
+++ b/default.podenv
@@ -12,31 +12,14 @@ let packages =
       , "findutils"
       ]
 
-let dhall-json =
-      { url =
-          "https://github.com/dhall-lang/dhall-haskell/releases/download/1.29.0/dhall-json-1.6.1-x86_64-linux.tar.bz2"
-      , hash =
-          "7e65f933fb215629d18d23bc774688c598d4c11b62865f3546ee23ae36b25290"
-      , dest = "/usr/local/bin"
-      , archive = Some "--strip-components=2 -j --mode='a+x'"
-      }
-
-let dhall =
-          dhall-json
-      //  { url =
-              "https://github.com/dhall-lang/dhall-haskell/releases/download/1.29.0/dhall-1.29.0-x86_64-linux.tar.bz2"
-          , hash =
-              "e273db3a83919aac183cf3273e262446d89da3f61690d7a1a6299748377855d1"
-          }
-
 in  Podenv.Env::{
     , name = "podenv-unittests"
     , description = Some "Run podenv unittests"
     , mounts = Some
-        [ Hub.Functions.mkMountMap "~/.cache/dhall"
-        , Hub.Functions.mkMountMap "~/.cache/dhall-haskell"
-        , Hub.Functions.mkMount "~/git/github.com/podenv/hub" "../hub"
-        ]
+      [ Hub.Functions.mkMountMap "~/.cache/dhall"
+      , Hub.Functions.mkMountMap "~/.cache/dhall-haskell"
+      , Hub.Functions.mkMount "~/git/github.com/podenv/hub" "../hub"
+      ]
     , capabilities = Podenv.Capabilities::{
       , mount-cwd = Some True
       , uidmap = Some True
@@ -48,22 +31,18 @@ in  Podenv.Env::{
 
         in  Hub.Functions.containerFromText
               (     ''
-                    FROM registry.fedoraproject.org/fedora:30
+                    FROM registry.fedoraproject.org/fedora:latest
                     RUN dnf install -y ${concat " " packages}
                     RUN useradd -u 1000 -m user
                     ''
-                ++  Hub.Functions.download "~/.cache/podenv/buildStore" dhall
+                ++  Hub.Environments.Dhall.Commands.`1.33`.base
                 ++  "\n"
-                ++  Hub.Functions.download
-                      "~/.cache/podenv/buildStore"
-                      dhall-json
+                ++  Hub.Environments.Dhall.Commands.`1.33`.json
               )
     , container-update = Hub.Functions.containerFromText "RUN dnf update -y"
     , build-env = Some Podenv.BuildEnv::{
       , mounts =
-        [ Hub.Functions.mkMountMap "~/.cache/podenv/buildStore"
-        , Hub.Functions.mkMount "/var/cache/dnf" "~/.cache/podenv/dnf"
-        ]
+        [ Hub.Functions.mkMount "/var/cache/dnf" "~/.cache/podenv/dnf" ]
       }
     , command = Some [ "make" ]
     }

--- a/podenv/capabilities.py
+++ b/podenv/capabilities.py
@@ -18,8 +18,9 @@ This module defines the capabilities
 
 import os
 import re
+from pathlib import Path
 from typing import Tuple, List, Set, Optional
-from podenv.context import ExecContext, Path, Capability
+from podenv.context import ExecContext, Capability
 
 
 def needUser(capability: str) -> None:

--- a/podenv/dhall.py
+++ b/podenv/dhall.py
@@ -23,9 +23,9 @@ from typing import Any, Dict, Optional, Union
 
 DEFAULT_PATH = Path("~/.local/bin/dhall-to-json").expanduser()
 DEFAULT_URL = "https://github.com/dhall-lang/dhall-haskell/releases/download/"\
-    "1.30.0/dhall-json-1.6.2-x86_64-linux.tar.bz2"
+    "1.33.1/dhall-json-1.7.0-x86_64-linux.tar.bz2"
 DEFAULT_HASH = \
-    "ea37627c4e19789af33def099d4cb145b874c03b4d5b98cb33ce06be1debf4f3"
+    "cc9fc70e492d35a3986183b589a435653e782f67cda51d33a935dff1ddd15aec"
 
 Input = Union[Path, str]
 Env = Optional[Dict[str, str]]

--- a/podenv/pod.py
+++ b/podenv/pod.py
@@ -167,7 +167,8 @@ def setupVolumes(volumes: Volumes) -> None:
     existingVolumes: Set[str] = set()
     if volumesList:
         for volume in volumesList:
-            existingVolumes.add(volume['name'])
+            volume_name = volume.get('Name') or volume.get('name')
+            existingVolumes.add(volume_name)
     for volume in volumes.values():
         if volume.name not in existingVolumes:
             log.info(f"Creating volume {volume.name}")

--- a/tests/config/common-image.dhall
+++ b/tests/config/common-image.dhall
@@ -5,22 +5,18 @@ let Env = Podenv.Env.Type
 
 let basic-env
     : forall (name : Text) -> Env
-    =     \(name : Text)
-      ->  Podenv.Env::{
-          , name = name
-          , image = Some name
-          , command = Some [ name ]
-          }
+    = \(name : Text) ->
+        Podenv.Env::{ name, image = Some name, command = Some [ name ] }
 
 let default-envs = [ basic-env "firefox", basic-env "emacs" ]
 
 let update-image
     : forall (image : Text) -> forall (envs : List Env) -> List Env
-    =     \(image : Text)
-      ->  (env:PODENV_HUB).Prelude.List.map
-            Env
-            Env
-            (\(env : Env) -> env // { image = Some image })
+    = \(image : Text) ->
+        (env:PODENV_HUB).Prelude.List.map
+          Env
+          Env
+          (\(env : Env) -> env // { image = Some image })
 
 let image = "shared-image-name"
 

--- a/tests/config/container-file.dhall
+++ b/tests/config/container-file.dhall
@@ -2,37 +2,37 @@
 let Podenv = env:PODENV_PRELUDE
 
 let mkBuildEnv =
-      \(mounts : List Podenv.Mount.Type) -> Podenv.BuildEnv::{ mounts = mounts }
+      \(mounts : List Podenv.Mount.Type) -> Podenv.BuildEnv::{ mounts }
 
 let mkMount =
-          \(container : Text)
-      ->  \(host : Text)
-      ->  { host-path = host, container-path = container }
+      \(container : Text) ->
+      \(host : Text) ->
+        { host-path = host, container-path = container }
 
 let fedoraImage =
-          \(packages : List Text)
-      ->  let concat = (env:PODENV_HUB).Prelude.Text.concatSep
+      \(packages : List Text) ->
+        let concat = (env:PODENV_HUB).Prelude.Text.concatSep
 
-          in  { container-file = Some
-                  [ Podenv.Task::{
-                    , name = Some "TODO: expand this..."
-                    , command = Some
-                        ''
-                        FROM registry.fedoraproject.org/fedora:30
-                        RUN dnf install -y https://dowload1.rpmfusion.org/free/...
-                        RUN dnf install -y ${concat " " packages}
-                        ''
-                    }
-                  ]
-              , container-update = Some
-                  [ Podenv.Task::{
-                    , name = Some "Update package"
-                    , command = Some "dnf update -y"
-                    }
-                  ]
-              , build-env =
-                  mkBuildEnv [ mkMount "/var/cache/dnf" "~/.cache/podenv/dnf" ]
-              }
+        in  { container-file = Some
+              [ Podenv.Task::{
+                , name = Some "TODO: expand this..."
+                , command = Some
+                    ''
+                    FROM registry.fedoraproject.org/fedora:30
+                    RUN dnf install -y https://dowload1.rpmfusion.org/free/...
+                    RUN dnf install -y ${concat " " packages}
+                    ''
+                }
+              ]
+            , container-update = Some
+              [ Podenv.Task::{
+                , name = Some "Update package"
+                , command = Some "dnf update -y"
+                }
+              ]
+            , build-env =
+                mkBuildEnv [ mkMount "/var/cache/dnf" "~/.cache/podenv/dnf" ]
+            }
 
 in  [     fedoraImage [ "firefox", "ffmpeg", "mesa-dri-drivers" ]
       //  { name = "firefox", capabilities = { x11 = True, dri = True } }

--- a/tests/config/hubconfigs.dhall
+++ b/tests/config/hubconfigs.dhall
@@ -14,13 +14,13 @@ let Fedora =
       }
 
 let {- When the env, package and command is a single name -} mkSimple =
-          \(name : Text)
-      ->  \(description : Text)
-      ->  { name = name
-          , description = Some description
-          , packages = Some [ name ]
-          , command = Some [ name ]
-          }
+      \(name : Text) ->
+      \(description : Text) ->
+        { name
+        , description = Some description
+        , packages = Some [ name ]
+        , command = Some [ name ]
+        }
 
 let X11 = { x11 = Some True }
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -62,6 +62,7 @@ class TestConfig(TestCase):
 
 
 @skipIf(not Path("/usr/local/bin/dhall-to-json").expanduser().exists() and
+        not Path("/usr/bin/dhall-to-json").expanduser().exists() and
         not Path("~/.local/bin/dhall-to-json").expanduser().exists(),
         "dhall-to-json is missing")
 class TestDhallConfig(TestCase):

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -35,7 +35,8 @@ class TestConfig(TestCase):
         env.user = User("user", Path("/home/user"), 1000)
         ctx = podenv.env.prepareEnv(env, [])
         execCommand = " ".join(ctx.getArgs())
-        self.assertIn("-v /home/user/git:/home/user/git", execCommand)
+        hostPath = str(Path("~/git").expanduser().resolve())
+        self.assertIn("-v %s:/home/user/git" % hostPath, execCommand)
 
     def test_volumes(self):
         env = fakeEnv("gertty", dict(


### PR DESCRIPTION
I'm using podman v2 2.0.1. It is probably related. Here is my output.

[fabien@ceres ~]$ podman volume ls --format json
[
  {
    "Name": "dhall-editor-config",
    "Driver": "local",
    "Mountpoint": "/var/home/fabien/.local/share/containers/storage/volumes/dhall-editor-config/_data",
    "CreatedAt": "2020-07-03T17:07:35.276148197+02:00",
    "Labels": {

    },
    "Scope": "local",
    "Options": {

    },
    "UID": 0,
    "GID": 0,
    "Anonymous": false
  }
]