### PR TITLE
[cli] Handle errors using either

### DIFF
--- a/src/Podenv/Main.hs
+++ b/src/Podenv/Main.hs
@@ -133,8 +133,8 @@ cliConfigLoad :: CLI -> IO (Application, Maybe BuildEnv, RuntimeEnv)
 cliConfigLoad cli@CLI {..} = do
   system <- Podenv.Config.loadSystem
   config <- Podenv.Config.load selector configExpr
-  let (args, (builderM, baseApp)) = Podenv.Config.select config (maybeToList selector <> extraArgs)
-      app = cliPrepare cli args baseApp
+  (args, (builderM, baseApp)) <- mayFail $ Podenv.Config.select config (maybeToList selector <> extraArgs)
+  let app = cliPrepare cli args baseApp
       be = Podenv.Build.initBuildEnv app <$> builderM
       re = RuntimeEnv {detach, k8s, verbose, system}
   pure (app, be, re)

--- a/src/Podenv/Prelude.hs
+++ b/src/Podenv/Prelude.hs
@@ -4,6 +4,8 @@ module Podenv.Prelude
     foldM,
     lookup,
     getEnv,
+    orDie,
+    mayFail,
 
     -- * xdg
     getCacheDir,
@@ -41,8 +43,17 @@ import Relude.Extra.Lens (Lens')
 import System.Directory
 import System.Environment (getEnv)
 import System.FilePath.Posix (hasTrailingPathSeparator, takeDirectory, takeFileName, (</>))
+import System.IO (hPutStrLn)
 import System.Posix.Types (UserID)
 import System.Posix.User (getRealUserID)
+
+orDie :: Maybe a -> Text -> Either Text a
+orDie (Just a) _ = Right a
+orDie Nothing e = Left e
+
+mayFail :: Either Text a -> IO a
+mayFail (Right a) = pure a
+mayFail (Left msg) = hPutStrLn stderr ("Error: " <> toString msg) >> exitFailure >> fail "over"
 
 (?~) :: ASetter s t a (Maybe b) -> b -> s -> t
 l ?~ b = set l (Just b)

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -12,6 +12,7 @@ import qualified Podenv.Config
 import Podenv.Dhall (Application (..))
 import qualified Podenv.Dhall
 import qualified Podenv.Main
+import Podenv.Prelude (mayFail)
 import qualified Podenv.Runtime
 import System.Environment (getEnv, setEnv)
 import Test.Hspec
@@ -35,8 +36,8 @@ spec config = describe "unit tests" $ do
     it "load nested" $ loadTest "{ a = { b = env, c = env}, d = env}" ["a.b", "a.c", "d"]
   describe "builder config" $ do
     it "load firefox" $ do
-      let (_, (builderM, baseApp)) = Podenv.Config.select config ["firefox"]
-          be = Podenv.Build.initBuildEnv baseApp <$> builderM
+      (_, (builderM, baseApp)) <- mayFail $ Podenv.Config.select config ["firefox"]
+      let be = Podenv.Build.initBuildEnv baseApp <$> builderM
       (_, app) <- Podenv.Build.prepare be baseApp
       runtime app `shouldBe` Podenv.Dhall.Image "localhost/firefox"
   -- ctx <- Podenv.Application.prepare app
@@ -85,7 +86,7 @@ spec config = describe "unit tests" $ do
         ["run", "--rm", "--security-opt", "label=disable", "--network", "none", "--volume", "/tmp:/tmp", "--volume", "/home/data:/tmp/data", "--name", "image-8bfbaa", "ubi8"]
   where
     defRun xs = ["run", "--rm"] <> xs <> ["--name", "env", defImg]
-    defImg = ""
+    defImg = "ubi8"
     defRe = Podenv.Runtime.defaultRuntimeEnv
 
     podmanCliTest args expected = do
@@ -101,7 +102,7 @@ spec config = describe "unit tests" $ do
     cliTest code args expectedCode = do
       let cli@Podenv.Main.CLI {..} = parseCli args
       config' <- loadConfig (Podenv.Main.selector cli) code
-      let (args', (_, baseApp)) = Podenv.Config.select config' (maybeToList selector <> extraArgs)
+      (args', (_, baseApp)) <- mayFail $ Podenv.Config.select config' (maybeToList selector <> extraArgs)
       expected <- loadOne expectedCode
 
       let got = Podenv.Main.cliPrepare cli args' baseApp
@@ -130,7 +131,7 @@ spec config = describe "unit tests" $ do
             unlines $
               [ "let Podenv = env:PODENV",
                 "let Nix = Podenv.Nix",
-                "let def = Podenv.Application.default // { runtime = Podenv.Image \"\" }",
+                "let def = Podenv.Application.default // { runtime = Podenv.Image \"ubi8\" }",
                 "let env = def // { name = \"env\" }",
                 "let env2 = env // { name = \"beta\" } in",
                 code


### PR DESCRIPTION
This change replaces `error` with Lefts to enable better handling
and to avoid printing a stack trace when it is not necessary.

Fixes #30