### PR TITLE
add lowerbound  dhall >= 1.34

### DIFF
--- a/podenv.cabal
+++ b/podenv.cabal
@@ -45,7 +45,7 @@ library
   build-depends:    base < 5
                   , SHA
                   , containers
-                  , dhall
+                  , dhall >= 1.34
                   , directory
                   , either
                   , filepath


### PR DESCRIPTION
This allows building with cabal-install using mostly Fedora 34 Haskell packages for example.