### PR TITLE
correct the dhall lowerbound to 1.39

### DIFF
--- a/podenv.cabal
+++ b/podenv.cabal
@@ -54,7 +54,7 @@ library
   build-depends:    base < 5
                   , SHA
                   , containers
-                  , dhall >= 1.34
+                  , dhall >= 1.39
                   , directory
                   , either
                   , filepath


### PR DESCRIPTION
Earlier versions didn't actually build: eg 1.37 and 1.38 are missing Dhall.Marshal.Decode

I tested with stack lts-16 and all dhall releases from 1.35.0 to 1.38.1: they all failed to build.