### PR TITLE
[config] Support weakly typed configuration

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,4 +42,4 @@ jobs:
     - run: cabal haddock
     - run: cabal sdist
     - run: cabal check
-    - run: cabal install
+    - run: cabal install --installdir=/tmp --overwrite-policy=always

--- a/docs/howtos/image.md
+++ b/docs/howtos/image.md
@@ -10,8 +10,6 @@ In a file named *~/.config/podenv/image.dhall* write:
 -- | A custom runtime
 let Podenv = env:PODENV
 
-let Hub = Podenv.Hub
-
 let ca =
       Text/show
         ''
@@ -58,7 +56,7 @@ let extra =
       ENV KRB5CCNAME=/home/fedora/.ticket
       ''
 
-in  Podenv.Container (Hub.fedora.useImage ver extra packages // set-image)
+in  Podenv.Container (Podenv.Hub.fedora.useImage ver extra packages // set-image)
 ```
 
 ## Override applications

--- a/docs/tutorials/create.md
+++ b/docs/tutorials/create.md
@@ -11,14 +11,12 @@ it's configuration in a file, for example at *~/.config/podenv/gimp.dhall*
 write this content:
 
 ```dhall
-(env:PODENV).Application::{
-, name = "gimp"
-, runtime =
-    (env:PODENV).Containerfile
-      ''
-      FROM registry.fedoraproject.org/fedora
-      RUN dnf install -y gimp
-      ''
+{ name = "gimp",
+  runtime.containerfile =
+    ''
+    FROM registry.fedoraproject.org/fedora
+    RUN dnf install -y gimp
+    ''
 }
 ```
 
@@ -91,16 +89,14 @@ Since the gimp application will always need the `x11` capability, you update the
 configuration file *~/.config/podenv/gimp.dhall* to:
 
 ```dhall
-(env:PODENV).Application::{
-, name = "gimp"
-, runtime =
-    (env:PODENV).Containerfile
-      ''
-      FROM registry.fedoraproject.org/fedora
-      RUN dnf install -y gimp
-      ''
-, capabilities = (env:PODENV).Capabilities::{ x11 = True }
-, command = [ "gimp" ]
+{ name = "gimp",
+  runtime.containerfile =
+    ''
+    FROM registry.fedoraproject.org/fedora
+    RUN dnf install -y gimp
+    '',
+  capabilities.x11 = True,
+  command = [ "gimp" ]
 }
 ```
 

--- a/src/Podenv/Dhall.hs
+++ b/src/Podenv/Dhall.hs
@@ -26,20 +26,23 @@ hubCommit = $(Dhall.TH.staticDhallExpression "env:HUB_COMMIT as Text ? ./.git/mo
 podenvPackage :: Expr Void Void
 podenvPackage = $(Dhall.TH.staticDhallExpression "./hub/package.dhall")
 
-appType :: Expr Void Void
-appType = $(Dhall.TH.staticDhallExpression "(./hub/schemas/package.dhall).Application.Type")
-
-appDefault :: Expr Void Void
+appType, appDefault, runtimeType, containerBuildDefault :: Expr Void Void
+appType = $(Dhall.TH.staticDhallExpression "(./hub/schemas/Application.dhall).Type")
+runtimeType = $(Dhall.TH.staticDhallExpression "./hub/schemas/Runtime.dhall")
+containerBuildDefault = $(Dhall.TH.staticDhallExpression "(./hub/schemas/ContainerBuild.dhall).default")
 appDefault =
   $( let package = "(./hub/schemas/package.dhall)"
       in Dhall.TH.staticDhallExpression (package <> ".Application.default // { runtime = " <> package <> ".Image \"\" }")
    )
 
+capsDefault :: Expr Void Void
+capsDefault = $(Dhall.TH.staticDhallExpression "(./hub/schemas/Capabilities.dhall).default")
+
 hubNixBuilder :: Expr Void Void
 hubNixBuilder = $(Dhall.TH.staticDhallExpression "./hub/Builders/nix.dhall")
 
 systemConfigDefault :: Expr Void Void
-systemConfigDefault = $(Dhall.TH.staticDhallExpression "(./hub/schemas/package.dhall).System.default")
+systemConfigDefault = $(Dhall.TH.staticDhallExpression "(./hub/schemas/System.dhall).default")
 
 -- | Generate Haskell Types from Dhall Types.
 -- See: https://hackage.haskell.org/package/dhall-1.39.0/docs/Dhall-TH.html

--- a/src/Podenv/Main.hs
+++ b/src/Podenv/Main.hs
@@ -192,7 +192,8 @@ printApps configTxt = do
         Podenv.Config.ConfigDefault app -> [("default", Podenv.Config.Lit app)]
         Podenv.Config.ConfigApplication atom -> [("default", atom)]
         Podenv.Config.ConfigApplications xs -> xs
-      showApp' app = "Application" <> maybe "" (\desc -> " (" <> desc <> ")") (app ^. appDescription)
+      showApp' (Podenv.Config.ApplicationRecord app) =
+        "Application" <> maybe "" (\desc -> " (" <> desc <> ")") (app ^. appDescription)
       showConfig = \case
         Podenv.Config.Lit app -> showApp' app
         Podenv.Config.LamArg name f -> "λ " <> show name <> " → " <> showApp' (f ("<" <> show name <> ">"))

--- a/test/config.dhall
+++ b/test/config.dhall
@@ -5,4 +5,4 @@ let fedora =
         Podenv.Container
           Podenv.ContainerBuild::{ containerfile = "FROM fedora" }
 
-in  { firefox = Podenv.Application::{ runtime = fedora [ "firefox" ] } }
+in  { firefox.runtime = fedora [ "firefox" ] }


### PR DESCRIPTION
This change enables the configuration to skip record completion so
that this configuration is now valid:

```dhall
{ name = "gimp"
, runtime.containerfile
  =
    ''
    FROM registry.fedoraproject.org/fedora
    RUN dnf install -y gimp
    ''
}
```