### PR TITLE
[test] Enable reproducable runs using a purePrepare helper

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,7 @@ jobs:
           ${{ runner.os }}-
     - run: cabal update
     - run: cabal build --enable-tests
-#     - run: cabal test --enable-tests --test-show-details=direct
+    - run: cabal test --enable-tests --test-show-details=direct
     - run: cabal haddock
     - run: cabal sdist
     - run: cabal check

--- a/podenv.cabal
+++ b/podenv.cabal
@@ -73,6 +73,7 @@ library
                   , Podenv.Config
                   , Podenv.Context
                   , Podenv.Dhall
+                  , Podenv.Env
                   , Podenv.Main
                   , Podenv.Prelude
                   , Podenv.Runtime

--- a/src/Podenv/Env.hs
+++ b/src/Podenv/Env.hs
@@ -1,0 +1,31 @@
+{-# LANGUAGE TemplateHaskell #-}
+{-# OPTIONS_GHC -Wno-missing-signatures #-}
+{-# OPTIONS_GHC -fno-warn-missing-export-lists #-}
+
+-- | The platform environment
+module Podenv.Env where
+
+import Lens.Family.TH (makeLenses)
+import Podenv.Prelude
+
+data AppEnv = AppEnv
+  { _hostXdgRunDir :: Maybe FilePath,
+    _hostHomeDir :: Maybe FilePath,
+    _hostCwd :: FilePath,
+    _hostUid :: UserID,
+    _appHomeDir :: Maybe FilePath
+  }
+  deriving (Show)
+
+$(makeLenses ''AppEnv)
+
+type AppEnvT a = ReaderT AppEnv IO a
+
+new :: IO AppEnv
+new =
+  AppEnv
+    <$> lookupEnv "XDG_RUNTIME_DIR"
+    <*> lookupEnv "HOME"
+    <*> getCurrentDirectory
+    <*> getRealUserID
+    <*> pure Nothing

--- a/src/Podenv/Main.hs
+++ b/src/Podenv/Main.hs
@@ -29,6 +29,7 @@ import Podenv.Build (BuildEnv (beInfos, beName, beUpdate))
 import qualified Podenv.Build
 import qualified Podenv.Config
 import Podenv.Dhall
+import qualified Podenv.Env
 import Podenv.Prelude
 import Podenv.Runtime (Context, RuntimeEnv (..))
 import qualified Podenv.Runtime

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -11,6 +11,7 @@ import qualified Podenv.Build
 import qualified Podenv.Config
 import Podenv.Dhall (Application (..))
 import qualified Podenv.Dhall
+import Podenv.Env
 import qualified Podenv.Main
 import Podenv.Prelude (mayFail)
 import qualified Podenv.Runtime
@@ -99,9 +100,18 @@ spec config = describe "unit tests" $ do
     defImg = "ubi8"
     defRe = Podenv.Runtime.defaultRuntimeEnv
 
+    testEnv =
+      AppEnv
+        { _hostXdgRunDir = Just "/run/user/1000",
+          _hostHomeDir = Just "/home/user",
+          _hostCwd = "/usr/src/podenv",
+          _hostUid = 1000,
+          _appHomeDir = Just "/home/fedora"
+        }
+
     podmanCliTest args expected = do
       (app, mode, _, _) <- Podenv.Main.cliConfigLoad (parseCli args)
-      ctx <- Podenv.Application.prepare app mode
+      ctx <- Podenv.Application.preparePure testEnv app mode
       Podenv.Runtime.podmanRunArgs defRe ctx `shouldBe` expected
 
     podmanTest code expected = do


### PR DESCRIPTION
This change introduces a global Podenv.Env so that runtime context
path can be set by the tests.