### PR TITLE
[wayland] add missing environment for screenshare

### DIFF
--- a/src/Podenv/Application.hs
+++ b/src/Podenv/Application.hs
@@ -177,6 +177,7 @@ setWayland' skt ctx = do
         . Ctx.addEnv "GDK_BACKEND" "wayland"
         . Ctx.addEnv "QT_QPA_PLATFORM" "wayland"
         . Ctx.addEnv "WAYLAND_DISPLAY" (toText skt)
+        . Ctx.addEnv "XDG_SESSION_TYPE" "wayland"
         . Ctx.addMount "/dev/shm" Ctx.tmpfs
 
 setPipewire :: Ctx.Context -> AppEnvT Ctx.Context

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -75,7 +75,7 @@ spec config = describe "unit tests" $ do
   describe "podman cli" $ do
     it "run minimal" $ podmanCliTest ["image:ubi8"] ["run", "--rm", "--network", "none", "--name", "image-8bfbaa", "ubi8"]
     it "wayland disable selinux" $
-      let cmd = ["run", "--rm", "--security-opt", "label=disable", "--network", "none", "--env", "GDK_BACKEND=wayland", "--env", "QT_QPA_PLATFORM=wayland", "--env", "WAYLAND_DISPLAY=wayland-0", "--env", "XDG_RUNTIME_DIR=/run/user", "--mount", "type=tmpfs,destination=/dev/shm", "--volume", "/etc/machine-id:/etc/machine-id", "--mount", "type=tmpfs,destination=/run/user", "--volume", "/run/user/1000/wayland-0:/run/user/wayland-0", "--name", "image-8bfbaa", "ubi8"]
+      let cmd = ["run", "--rm", "--security-opt", "label=disable", "--network", "none", "--env", "GDK_BACKEND=wayland", "--env", "QT_QPA_PLATFORM=wayland", "--env", "WAYLAND_DISPLAY=wayland-0", "--env", "XDG_RUNTIME_DIR=/run/user", "--env", "XDG_SESSION_TYPE=wayland", "--mount", "type=tmpfs,destination=/dev/shm", "--volume", "/etc/machine-id:/etc/machine-id", "--mount", "type=tmpfs,destination=/run/user", "--volume", "/run/user/1000/wayland-0:/run/user/wayland-0", "--name", "image-8bfbaa", "ubi8"]
        in podmanCliTest ["--wayland", "image:ubi8"] cmd
     it "hostfile are substituted" $
       let cmd = ["run", "--rm", "--network", "none", "--volume", "/proc/cmdline:/data/cmdline", "--volume", "/etc/hosts:/data/hosts", "--name", "image-8bfbaa", "ubi8", "cat", "/data/hosts", "/data/cmdline"]


### PR DESCRIPTION
This seems to be enough for application to start using pipewire
through dbus for screenshare.

Fixes #54 