### PR TITLE
Use an infra container for the keep capability

### DIFF
--- a/src/Podenv/Context.hs
+++ b/src/Podenv/Context.hs
@@ -70,7 +70,8 @@ data Context = Context
     _hostname :: Maybe Text,
     _interactive :: Bool,
     _terminal :: Bool,
-    _keep :: Bool
+    _keep :: Bool,
+    _detach :: Bool
   }
   deriving (Show)
 
@@ -98,7 +99,8 @@ defaultContext _name _image =
       _hostname = Nothing,
       _interactive = False,
       _terminal = False,
-      _keep = False
+      _keep = False,
+      _detach = False
     }
 
 rwHostPath :: FilePath -> Volume

--- a/src/Podenv/Main.hs
+++ b/src/Podenv/Main.hs
@@ -93,8 +93,6 @@ data CLI = CLI
     -- runtime env:
     update :: Bool,
     verbose :: Bool,
-    detach :: Bool,
-    k8s :: Bool,
     -- app modifiers:
     capsOverride :: [Capabilities -> Capabilities],
     shell :: Bool,
@@ -121,8 +119,6 @@ cliParser =
     -- runtime env:
     <*> switch (long "update" <> help "Update the runtime")
     <*> switch (long "verbose" <> help "Increase verbosity")
-    <*> pure False -- switch (long "detach" <> help "Start the application in tmux or kubernetes")
-    <*> pure False -- switch (long "k8s" <> help "Start the application in kubernetes and attach with kubectl logs or exec unless --detach")
     -- app modifiers:
     <*> capsParser
     <*> switch (long "shell" <> help "Start a shell instead of the application command")
@@ -180,7 +176,7 @@ cliConfigLoad cli@CLI {..} = do
   (args, (builderM, baseApp)) <- mayFail $ Podenv.Config.select config (maybeToList selector <> extraArgs)
   let app = cliPrepare cli args baseApp
       be = Podenv.Build.initBuildEnv app <$> builderM
-      re = RuntimeEnv {detach, k8s, verbose, system}
+      re = RuntimeEnv {verbose, system}
       mode = if shell then Podenv.Application.Shell else Podenv.Application.Regular
   pure (app, mode, be, re)
 

--- a/src/Podenv/Runtime.hs
+++ b/src/Podenv/Runtime.hs
@@ -42,15 +42,13 @@ showPodmanCmd :: RuntimeEnv -> Context -> Text
 showPodmanCmd re = show . P.proc "podman" . podmanRunArgs re
 
 data RuntimeEnv = RuntimeEnv
-  { detach :: Bool,
-    k8s :: Bool,
-    verbose :: Bool,
+  { verbose :: Bool,
     system :: SystemConfig
   }
   deriving (Show)
 
 defaultRuntimeEnv :: RuntimeEnv
-defaultRuntimeEnv = RuntimeEnv False False True defaultSystemConfig
+defaultRuntimeEnv = RuntimeEnv True defaultSystemConfig
 
 type ContextEnvT a = ReaderT RuntimeEnv IO a
 


### PR DESCRIPTION
This change creates a `sleep infinity` container when the keep capability
is used so that the context stays alive after the first instance exit.
This prevent further instances to be killed nu-expectedly.