### PR TITLE
[runtime] Add the uid to the xdg rundir

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -7,8 +7,7 @@ pull_request_rules:
       - check-success=Haskell GHC 8.10
     actions:
       merge:
-        method: rebase
-        strict: smart+fasttrack
+        method: merge
   - actions:
       delete_head_branch: {}
     name: Delete head branch after merge

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -77,7 +77,7 @@ spec config = describe "unit tests" $ do
   describe "podman cli" $ do
     it "run minimal" $ podmanCliTest ["image:ubi8"] ["run", "--rm", "--network", "none", "--name", "image-8bfbaa", "ubi8"]
     it "wayland disable selinux" $
-      let cmd = ["run", "--rm", "--security-opt", "label=disable", "--network", "none", "--env", "GDK_BACKEND=wayland", "--env", "QT_QPA_PLATFORM=wayland", "--env", "WAYLAND_DISPLAY=wayland-0", "--env", "XDG_RUNTIME_DIR=/run/user", "--env", "XDG_SESSION_TYPE=wayland", "--mount", "type=tmpfs,destination=/dev/shm", "--volume", "/etc/machine-id:/etc/machine-id", "--mount", "type=tmpfs,destination=/run/user", "--volume", "/run/user/1000/wayland-0:/run/user/wayland-0", "--name", "image-8bfbaa", "ubi8"]
+      let cmd = ["run", "--rm", "--security-opt", "label=disable", "--network", "none", "--env", "GDK_BACKEND=wayland", "--env", "QT_QPA_PLATFORM=wayland", "--env", "WAYLAND_DISPLAY=wayland-0", "--env", "XDG_RUNTIME_DIR=/run/user/1000", "--env", "XDG_SESSION_TYPE=wayland", "--mount", "type=tmpfs,destination=/dev/shm", "--volume", "/etc/machine-id:/etc/machine-id", "--mount", "type=tmpfs,destination=/run/user", "--volume", "/run/user/1000/wayland-0:/run/user/1000/wayland-0", "--name", "image-8bfbaa", "ubi8"]
        in podmanCliTest ["--wayland", "image:ubi8"] cmd
     it "hostfile are substituted" $
       let cmd = ["run", "--rm", "--network", "none", "--volume", "/proc/cmdline:/data/cmdline", "--volume", "/etc/hosts:/data/hosts", "--name", "image-8bfbaa", "ubi8", "cat", "/data/hosts", "/data/cmdline"]


### PR DESCRIPTION
The path of the gpg-agent socket contains the full host path,
thus podenv needs to replicate the original location, instead of using
the simpler `/run/user` path.