### PR TITLE
Add initial support for Nix Flakes

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,17 @@ Run a podenv application: `podenv gimp ./image.png`
 
 … builds a container and starts the following command: `podman run [wayland args] --volume $(pwd)/image.png:/data/image.png gimp /data/image.png`
 
+### Container rootfs
+
+Run a container image rootfs with bubblewrap:
+
+```
+# Extract filesystem
+podenv --volume rawhide:/mnt  image:registry.fedoraproject.org/fedora:rawhide bash -c "tar --one-file-system -cvf - / | tar -C /mnt -xf -" > /dev/null`
+# Run shell
+podenv --network --rw --root rootfs:rawhide
+```
+
 # Documentation
 
 Podenv documentation is organized into the following [four sections][documentation]:

--- a/README.md
+++ b/README.md
@@ -32,11 +32,11 @@ Run a rootfs: `podenv --shell rootfs:/`
 
 … starts the following command: `bwrap --die-with-parent --unshare-pid --unshare-ipc --unshare-uts --unshare-net --ro-bind /usr /usr --ro-bind /lib64 /lib64 --ro-bind /bin /bin --ro-bind /sbin /sbin --ro-bind /etc /etc --proc /proc --dev /dev --perms 01777 --tmpfs /tmp --clearenv --setenv HOME /var/home/fedora /bin/sh`
 
-### Nix packages
+### Nix flakes
 
-Run a nix package: `podenv nix:"(import <nixpkgs> {}).hello" hello`
+Run a nix package: `podenv nixpkgs#hello`
 
-… instantiates the expression and runs the `hello` command in a container.
+… runs the installable using bubblewrap.
 
 ### Applications
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Here are some demo use cases:
 
 ### Container image
 
-Run a container image: `podenv --cwd --shell image:ubi8`
+Run a container image: `podenv --rw --cwd --shell image:ubi8`
 
 … starts the following command: `podman run -it --detach-keys '' --network none --rm --volume $(pwd):/data:Z --workdir /data ubi8 /bin/bash`
 

--- a/podenv.cabal
+++ b/podenv.cabal
@@ -19,7 +19,6 @@ category:           Development
 extra-source-files: test/*.dhall
                     hub/*.dhall
                     hub/**/*.dhall
-                    hub/Applications/*.nix
                     .git/modules/hub/HEAD
 
 source-repository head
@@ -57,6 +56,7 @@ library
                   , containers
                   , dhall >= 1.39
                   , directory
+                  , unix
                   , either
                   , filepath
                   , gitrev

--- a/src/Podenv/Application.hs
+++ b/src/Podenv/Application.hs
@@ -91,7 +91,7 @@ doPrepare app mode ctxName = do
       Nix _ -> Podenv.Build.nixRuntime
 
     validate ctx = case runtimeCtx of
-      Ctx.Bubblewrap _ | null (ctx ^. Ctx.command) -> error "Bubblewrap requires a command"
+      Ctx.Bubblewrap _ | null (ctx ^. Ctx.command) -> ctx & Ctx.command .~ ["/bin/sh"]
       _ -> ctx
 
     modifiers :: Ctx.Context -> Ctx.Context

--- a/src/Podenv/Application.hs
+++ b/src/Podenv/Application.hs
@@ -186,7 +186,8 @@ capsToggle =
     Cap "cwd" "mount cwd" capCwd setCwd,
     Cap "keep" "keep after run" capKeep (contextSet Ctx.keep True),
     Cap "network" "enable network" capNetwork (contextSet Ctx.network True),
-    Cap "hostfile" "mount command file arg" capHostfile pure
+    Cap "hostfile" "mount command file arg" capHostfile pure,
+    Cap "rw" "mount rootfs rw" capRw (contextSet Ctx.ro False)
   ]
 
 setTerminal :: Ctx.Context -> AppEnvT Ctx.Context

--- a/src/Podenv/Application.hs
+++ b/src/Podenv/Application.hs
@@ -24,6 +24,7 @@ where
 import qualified Data.Map
 import qualified Data.Text as Text
 import qualified Data.Text.IO as Text
+import qualified Podenv.Build
 import Podenv.Dhall
 import Podenv.Env
 import Podenv.Prelude
@@ -86,7 +87,8 @@ doPrepare app mode ctxName = do
     runtimeCtx = case app ^. appRuntime of
       Image x -> Ctx.Container $ Ctx.ImageName x
       Rootfs root -> Ctx.Bubblewrap $ toString root
-      _ -> error "Can't prepare a non runtime Image application"
+      Container cb -> Podenv.Build.containerBuildRuntime cb
+      Nix _ -> Podenv.Build.nixRuntime
 
     validate ctx = case runtimeCtx of
       Ctx.Bubblewrap _ | null (ctx ^. Ctx.command) -> error "Bubblewrap requires a command"

--- a/src/Podenv/Context.hs
+++ b/src/Podenv/Context.hs
@@ -73,6 +73,7 @@ data Context = Context
     -- | container volumes
     _mounts :: Map FilePath Volume,
     _syscaps :: [Capability],
+    _ro :: Bool,
     -- | container devices
     _devices :: Set FilePath,
     _hostname :: Maybe Text,
@@ -103,6 +104,8 @@ defaultContext _name _runtimeCtx =
       _mounts = mempty,
       _devices = mempty,
       _syscaps = mempty,
+      -- TODO: make ro work for podman
+      _ro = True,
       _workdir = Nothing,
       _hostname = Nothing,
       _interactive = False,

--- a/src/Podenv/Dhall.hs
+++ b/src/Podenv/Dhall.hs
@@ -38,9 +38,6 @@ appDefault =
 capsDefault :: Expr Void Void
 capsDefault = $(Dhall.TH.staticDhallExpression "(./hub/schemas/Capabilities.dhall).default")
 
-hubNixBuilder :: Expr Void Void
-hubNixBuilder = $(Dhall.TH.staticDhallExpression "./hub/Builders/nix.dhall")
-
 systemConfigDefault :: Expr Void Void
 systemConfigDefault = $(Dhall.TH.staticDhallExpression "(./hub/schemas/System.dhall).default")
 
@@ -53,6 +50,7 @@ Dhall.TH.makeHaskellTypes
      in [ main "Capabilities",
           main "Application",
           main "ContainerBuild",
+          main "Flakes",
           main' "SystemConfig" "System",
           Dhall.TH.MultipleConstructors "Provider" "./hub/schemas/Provider.dhall",
           Dhall.TH.MultipleConstructors "Runtime" "./hub/schemas/Runtime.dhall"
@@ -76,6 +74,10 @@ deriving instance Eq Provider
 deriving instance Show ContainerBuild
 
 deriving instance Eq ContainerBuild
+
+deriving instance Show Flakes
+
+deriving instance Eq Flakes
 
 deriving instance Show Capabilities
 

--- a/src/Podenv/Prelude.hs
+++ b/src/Podenv/Prelude.hs
@@ -32,6 +32,7 @@ module Podenv.Prelude
     getCurrentDirectory,
     doesFileExist,
     doesPathExist,
+    doesSymlinkExist,
     pathIsSymbolicLink,
     findExecutable,
     (</>),
@@ -54,6 +55,7 @@ module Podenv.Prelude
   )
 where
 
+import qualified Control.Exception
 import Control.Monad (foldM)
 import qualified Data.Text.IO
 import Lens.Family (ASetter, set, (%~), (.~), (^.))
@@ -63,6 +65,7 @@ import System.Directory
 import System.Environment
 import System.FilePath.Posix (hasTrailingPathSeparator, takeDirectory, takeFileName, (</>))
 import System.IO (hPutStrLn)
+import qualified System.Posix.Files
 import System.Posix.Types (UserID)
 import System.Posix.User (getRealUserID)
 
@@ -95,3 +98,10 @@ readFileM fp' = do
   if exist
     then liftIO $ Data.Text.IO.readFile fp'
     else pure ""
+
+doesSymlinkExist :: FilePath -> IO Bool
+doesSymlinkExist fp =
+  either (const False) (const True) <$> checkFp
+  where
+    checkFp :: IO (Either Control.Exception.SomeException FilePath)
+    checkFp = Control.Exception.try $ System.Posix.Files.readSymbolicLink fp


### PR DESCRIPTION
- Use Bubblewrap for nix app runtime
- Cleanup the legacy Builder data which is no longer necessary

This change replaces the current nix runtime to work with Installable,
see: https://nixos.org/manual/nix/stable/command-ref/new-cli/nix.html#installables