### PR TITLE
Revert "Update to ghc-9.6.4"

### DIFF
--- a/.weeder.dhall
+++ b/.weeder.dhall
@@ -1,0 +1,3 @@
+{ roots = [ "Main.main", "Podenv.Prelude.lensName", "^Paths_.*" ]
+, type-class-roots = True
+}

--- a/.weeder.toml
+++ b/.weeder.toml
@@ -1,3 +1,0 @@
-roots = ["Main.main", "Podenv.Prelude.lensName", "^Paths_.*"]
-type-class-roots = true
-

--- a/flake.lock
+++ b/flake.lock
@@ -5,33 +5,33 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1713727902,
-        "narHash": "sha256-MI4s1jBmhoJyge70BU7/PJPzOmGnnvim2pwyAnM9PnI=",
+        "lastModified": 1681261331,
+        "narHash": "sha256-FFF4qeSOieKl3s5h6bpR5Tllz7aqSaF+pE5bkg+BSfM=",
         "owner": "podenv",
         "repo": "hspkgs",
-        "rev": "4750e01093a76c15eef7aa43bab8cd6e285c3fac",
+        "rev": "90eadd304c6375f926a0970f87b470e765e7f176",
         "type": "github"
       },
       "original": {
         "owner": "podenv",
         "repo": "hspkgs",
-        "rev": "4750e01093a76c15eef7aa43bab8cd6e285c3fac",
+        "rev": "90eadd304c6375f926a0970f87b470e765e7f176",
         "type": "github"
       }
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1711196146,
-        "narHash": "sha256-SDB2EjSDfHzg4vbsoTOf8vGydJJfjNRHIQgkjVI1XMM=",
+        "lastModified": 1672755833,
+        "narHash": "sha256-AmPzlvY1Y5codnytZCDn2wlhVa8rDHNib5wBWtcD7c4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b79cc961fe98b158ea051ae3c71616872ffe8212",
+        "rev": "3665c429d349fbda46b0651e554cca8434452748",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b79cc961fe98b158ea051ae3c71616872ffe8212",
+        "rev": "3665c429d349fbda46b0651e554cca8434452748",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,7 @@
 
   inputs = {
     hspkgs.url =
-      "github:podenv/hspkgs/4750e01093a76c15eef7aa43bab8cd6e285c3fac";
+      "github:podenv/hspkgs/90eadd304c6375f926a0970f87b470e765e7f176";
       # "path:///srv/github.com/podenv/hspkgs";
   };
 
@@ -49,7 +49,7 @@
 
       weeder_wrapper = pkgs.writeScriptBin "weeder" ''
         #!/bin/sh
-        exec ${pkgs.weeder}/bin/weeder --require-hs-files --config ./.weeder.toml
+        exec ${pkgs.weeder}/bin/weeder --require-hs-files --config ./.weeder.dhall
       '';
 
     in {

--- a/src/Podenv/Capability.hs
+++ b/src/Podenv/Capability.hs
@@ -36,12 +36,12 @@ prepare mode ar = do
     let ctx =
             defaultContext (app ^. appRuntime)
                 & (ctxNamespace .~ (ar ^. arMetadata . metaNamespace))
-                . (ctxName .~ (Name . mappend nsPrefix <$> ar ^. arMetadata . metaName))
-                . (ctxLabels .~ labels)
-                . setNetwork
-                . setHostname
-                . addSysCaps
-                . addEnvs
+                    . (ctxName .~ (Name . mappend nsPrefix <$> ar ^. arMetadata . metaName))
+                    . (ctxLabels .~ labels)
+                    . setNetwork
+                    . setHostname
+                    . addSysCaps
+                    . addEnvs
 
     setVolumes <- addVolumes (ar ^. arVolumes <> app ^. appVolumes)
 
@@ -218,15 +218,15 @@ setWayland = do
 setWayland' :: SocketName -> AppEnvT (Ctx.Context -> Ctx.Context)
 setWayland' (SocketName skt) = do
     shareSkt <- addXdgRun skt
-    pure
-        $ Ctx.directMount "/etc/machine-id"
-        . shareSkt
-        . Ctx.addEnv "GDK_BACKEND" "wayland"
-        . Ctx.addEnv "QT_QPA_PLATFORM" "wayland"
-        . Ctx.addEnv "WAYLAND_DISPLAY" (toText skt)
-        . Ctx.addEnv "SDL_VIDEODRIVER" "wayland"
-        . Ctx.addEnv "XDG_SESSION_TYPE" "wayland"
-        . Ctx.addMount "/dev/shm" Ctx.tmpfs
+    pure $
+        Ctx.directMount "/etc/machine-id"
+            . shareSkt
+            . Ctx.addEnv "GDK_BACKEND" "wayland"
+            . Ctx.addEnv "QT_QPA_PLATFORM" "wayland"
+            . Ctx.addEnv "WAYLAND_DISPLAY" (toText skt)
+            . Ctx.addEnv "SDL_VIDEODRIVER" "wayland"
+            . Ctx.addEnv "XDG_SESSION_TYPE" "wayland"
+            . Ctx.addMount "/dev/shm" Ctx.tmpfs
 
 setPipewire :: AppEnvT (Ctx.Context -> Ctx.Context)
 setPipewire = do
@@ -238,10 +238,10 @@ setDbus :: AppEnvT (Ctx.Context -> Ctx.Context)
 setDbus = do
     let skt = "bus" -- TODO discover skt name
     (sktPath, shareSkt) <- addXdgRun' skt
-    pure
-        $ Ctx.directMount "/etc/machine-id"
-        . Ctx.addEnv "DBUS_SESSION_BUS_ADDRESS" ("unix:path=" <> toText sktPath)
-        . shareSkt
+    pure $
+        Ctx.directMount "/etc/machine-id"
+            . Ctx.addEnv "DBUS_SESSION_BUS_ADDRESS" ("unix:path=" <> toText sktPath)
+            . shareSkt
 
 setVideo :: AppEnvT (Ctx.Context -> Ctx.Context)
 setVideo = do
@@ -254,8 +254,8 @@ setDri :: AppEnvT (Ctx.Context -> Ctx.Context)
 setDri = do
     let base = Ctx.addDevice "/dev/dri"
     nvidia <- isNVIDIAEnabled
-    pure
-        $ if nvidia
+    pure $
+        if nvidia
             then foldr ((.) . Ctx.addDevice) base nvidiaDevs
             else base
   where
@@ -266,10 +266,10 @@ setPulseaudio = do
     shareSkt <- addXdgRun "pulse"
     huid <- askL envHostUid
     let pulseServer = "/run/user/" <> show huid <> "/pulse/native"
-    pure
-        $ Ctx.directMount "/etc/machine-id"
-        . shareSkt
-        . Ctx.addEnv "PULSE_SERVER" pulseServer
+    pure $
+        Ctx.directMount "/etc/machine-id"
+            . shareSkt
+            . Ctx.addEnv "PULSE_SERVER" pulseServer
 
 getHomes :: Text -> AppEnvT (FilePath, FilePath)
 getHomes help = do
@@ -300,10 +300,8 @@ setGpg = do
 setX11 :: AppEnvT (Ctx.Context -> Ctx.Context)
 setX11 = do
     display <- askL envHostDisplay
-    pure
-        $ Ctx.directMount "/tmp/.X11-unix"
-        . Ctx.addEnv "DISPLAY" (toText display)
-        . Ctx.addMount "/dev/shm" Ctx.tmpfs
+    pure $
+        Ctx.directMount "/tmp/.X11-unix" . Ctx.addEnv "DISPLAY" (toText display) . Ctx.addMount "/dev/shm" Ctx.tmpfs
 
 setCwd :: AppEnvT (Ctx.Context -> Ctx.Context)
 setCwd = do

--- a/src/Podenv/Dhall.hs
+++ b/src/Podenv/Dhall.hs
@@ -113,7 +113,7 @@ defaultAppRes application =
         { metadata =
             defaultMetadata
                 & (metaName .~ name)
-                . (metaNamespace .~ (application ^. appNamespace))
+                    . (metaNamespace .~ (application ^. appNamespace))
         , kind = "Application"
         , apiVersion = "podenv/0.2"
         , network = maybe Private netFromNamespace (application ^. appNamespace)

--- a/src/Podenv/Env.hs
+++ b/src/Podenv/Env.hs
@@ -106,10 +106,9 @@ getRootfsHome :: UserID -> Maybe FilePath -> FilePath -> IO (Maybe FilePath)
 getRootfsHome _ (Just hostHome) "/" = pure $ Just hostHome
 getRootfsHome uid _ fp = do
     passwd <- readFileM (fp </> "etc/passwd")
-    pure
-        $ toString
-        . Data.List.NonEmpty.head
-        <$> Data.List.NonEmpty.nonEmpty (Data.Maybe.mapMaybe isUser $ Podenv.Prelude.lines passwd)
+    pure $
+        toString . Data.List.NonEmpty.head
+            <$> Data.List.NonEmpty.nonEmpty (Data.Maybe.mapMaybe isUser $ Podenv.Prelude.lines passwd)
   where
     isUser l = case Data.Text.splitOn ":" l of
         (_ : _ : uid' : _ : _ : home : _) | readMaybe (toString uid') == Just uid -> Just home

--- a/src/Podenv/Main.hs
+++ b/src/Podenv/Main.hs
@@ -59,8 +59,8 @@ main = do
     (ar, mode, gl, run) <- cliLoad cli
     ctx <- Podenv.Runtime.appToContext run mode ar
 
-    flip runReaderT gl
-        $ if showApplication
+    flip runReaderT gl $
+        if showApplication
             then putTextLn . showApp ar run =<< Podenv.Runtime.showCmd run Foreground ctx
             else do
                 let doUpdate = Podenv.Runtime.updateRuntime run (ar ^. arApplication . appRuntime)
@@ -237,8 +237,8 @@ cliConfigLoad volumesDir env config cli@CLI{..} = do
         caps = app ^. arApplication . appCapabilities
 
     notifier <-
-        Podenv.Notifications.pickNotifier
-            $ if caps ^. capWayland || caps ^. capX11
+        Podenv.Notifications.pickNotifier $
+            if caps ^. capWayland || caps ^. capX11
                 then Podenv.Notifications.Display
                 else Podenv.Notifications.Console
 

--- a/src/Podenv/Notifications.hs
+++ b/src/Podenv/Notifications.hs
@@ -75,7 +75,7 @@ pickNotifier output = do
         then pure consoleNotifier
         else do
             zenity <- hasZenity
-            pure
-                $ if zenity
+            pure $
+                if zenity
                     then zenityNotifier
                     else consoleNotifier

--- a/src/Podenv/Prelude.hs
+++ b/src/Podenv/Prelude.hs
@@ -82,7 +82,7 @@ l ?~ b = set l (Just b)
 setWhenNothing :: ASetter s t (Maybe b) (Maybe b) -> b -> s -> t
 l `setWhenNothing` b = l %~ maybe (Just b) Just
 
-askL :: (MonadReader s m) => Lens' s a -> m a
+askL :: MonadReader s m => Lens' s a -> m a
 askL l = do
     e <- ask
     pure $ e ^. l

--- a/src/Podenv/Runtime.hs
+++ b/src/Podenv/Runtime.hs
@@ -100,8 +100,8 @@ ensureResolvConf fp
   where
     getSymlinkPath = do
         realResolvConf <- System.Posix.Files.readSymbolicLink "/etc/resolv.conf"
-        pure
-            $ if "../" `isPrefixOf` realResolvConf
+        pure $
+            if "../" `isPrefixOf` realResolvConf
                 then drop 2 realResolvConf
                 else realResolvConf
 
@@ -305,7 +305,7 @@ createHeadlessRunEnv cfg appEnv =
     headlessEnv =
         appEnv
             & (envHostDisplay .~ ":0")
-            . (envHostWaylandSocket ?~ SocketName "wayland-1")
+                . (envHostWaylandSocket ?~ SocketName "wayland-1")
 
     appToHeadlessContext amode ar = do
         headlessContext <$> appToContext headlessRun amode ar
@@ -329,8 +329,8 @@ createHeadlessRunEnv cfg appEnv =
         vncCtx <- getHeadlessApp (ctx ^. ctxNamespace) "vnc"
         clientApp <- getApp (ctx ^. ctxNamespace) "vnc-viewer"
         clientCtx <-
-            liftIO
-                $ appToContext
+            liftIO $
+                appToContext
                     localRun
                     (Regular ["localhost"])
                     (clientApp & arNetwork .~ Shared "container:vnc")
@@ -376,7 +376,7 @@ checkImageExist imageName = do
     res <- P.runProcess (Podenv.Runtime.podman ["image", "exists", Text.unpack imageName])
     pure $ res == ExitSuccess
 
-withCacheFile :: (MonadIO m) => FilePath -> Text -> m () -> m ()
+withCacheFile :: MonadIO m => FilePath -> Text -> m () -> m ()
 withCacheFile fileName expected action = do
     cacheDir <- liftIO getCacheDir
     liftIO $ createDirectoryIfMissing True cacheDir
@@ -477,8 +477,7 @@ bwrapRunArgs GlobalEnv{..} ctx fp = toString <$> args
             <> concatMap (\(k, v) -> ["--setenv", toText k, v]) (Map.toAscList (ctx ^. ctxEnviron))
             <> cond (not (ctx ^. ctxTerminal)) ["--new-session"]
             <> maybe [] (\wd -> ["--chdir", toText wd]) (ctx ^. ctxWorkdir)
-            <> ctx
-            ^. ctxCommand
+            <> ctx ^. ctxCommand
 
 data GlobalEnv = GlobalEnv
     { verbose :: Bool
@@ -591,7 +590,7 @@ data PodmanStatus
       Unknown Text
     deriving (Show, Eq)
 
-getPodmanPodStatus :: (MonadIO m) => Name -> m PodmanStatus
+getPodmanPodStatus :: MonadIO m => Name -> m PodmanStatus
 getPodmanPodStatus (Name cname) = do
     (_, stdout', _) <- P.readProcess (podman ["inspect", Text.unpack cname, "--format", "{{.State.Status}}"])
     pure $ case stdout' of
@@ -611,18 +610,17 @@ ensureInfraNet ns = do
     case infraStatus of
         Running -> pure ()
         _ -> do
-            when (infraStatus /= NotFound)
-                $
+            when (infraStatus /= NotFound) $
                 -- Try to delete any left-over infra container
                 deletePodmanPod infraPod
 
             let cmd =
-                    podman
-                        $ map toString
-                        $ ["run", "--rm", "--name", unName infraPod]
-                        <> ["--detach"]
-                        <> ["ubi8"]
-                        <> ["sleep", "infinity"]
+                    podman $
+                        map toString $
+                            ["run", "--rm", "--name", unName infraPod]
+                                <> ["--detach"]
+                                <> ["ubi8"]
+                                <> ["sleep", "infinity"]
             debug $ show cmd
             P.runProcess_ cmd
 

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -54,8 +54,7 @@ spec (config, goldenConfig) = describe "unit tests" $ do
                 cfg <- maybe (loadConfig (configExpr cli)) pure configM
                 (ar, mode, gl, run) <- cliConfigLoad "/volumes" testEnv cfg cli
                 ctx <- Podenv.Runtime.appToContext run mode ar
-                mappend ("==== " <> show args <> "\n")
-                    . Text.replace " --" "\n  --"
+                mappend ("==== " <> show args <> "\n") . Text.replace " --" "\n  --"
                     <$> runReaderT (Podenv.Runtime.showCmd run Foreground ctx) gl
             mkGolden = mkGoldenConfig (Just goldenConfig)
             writeGolden :: [[String]] -> [[String]] -> IO ()
@@ -165,21 +164,21 @@ spec (config, goldenConfig) = describe "unit tests" $ do
         it "unset cap" $ cliTest (addCap "env" "wayland = True") ["--no-wayland"] "env"
         it "set volume" $ cliTest "env" ["--volume", "/tmp/test"] "env // { volumes = [\"/tmp/test\"]}"
         it "one args" $ cliTest "\\(a : Text) -> env // { description = Some a }" ["a"] "env // { description = Some \"a\"}"
-        it "two args"
-            $ cliTest
+        it "two args" $
+            cliTest
                 "\\(a : Text) -> \\(b : Text) -> env // { description = Some (a ++ b) }"
                 ["a", "b"]
                 "env // { description = Some \"ab\"}"
 
     describe "nix test" $ do
         it "nix run without args" $ nixTest "{ runtime.nix = \"test\"}" [] ["run", "test"]
-        it "nix run with args"
-            $ nixTest
+        it "nix run with args" $
+            nixTest
                 "{env, test = { runtime.nix = \"test\"}}"
                 ["test", "--help"]
                 ["run", "test", "--", "--help"]
-        it "nix run with shell"
-            $ nixTest
+        it "nix run with shell" $
+            nixTest
                 "{env, test = { runtime.nix = \"test\", command = [\"cmd\"]}}"
                 ["test", "--help"]
                 ["shell", "test", "--command", "cmd", "--help"]
@@ -191,28 +190,28 @@ spec (config, goldenConfig) = describe "unit tests" $ do
                 ctx <- runPrepare (Regular []) testEnv ar
                 Podenv.Runtime.podmanRunArgs defRe fg ctx (getImg ar) `shouldBe` expected
         it "run simple" $ podmanTest "env" (defRun ["--mount", "type=tmpfs,destination=/tmp"])
-        it "run simple root"
-            $ podmanTest
+        it "run simple root" $
+            podmanTest
                 "env // { capabilities.root = True }"
                 (defRun ["--user", "0", "--workdir", "/root", "--env", "HOME=/root", "--mount", "type=tmpfs,destination=/tmp", "--volume", "/data/podenv-home:/root"])
-        it "run syscaps"
-            $ podmanTest
+        it "run syscaps" $
+            podmanTest
                 "env // { syscaps = [\"NET_ADMIN\"] }"
                 (defRun ["--cap-add", "CAP_NET_ADMIN", "--mount", "type=tmpfs,destination=/tmp"])
-        it "run hostdir"
-            $ podmanTest
+        it "run hostdir" $
+            podmanTest
                 "env // { volumes = [\"/tmp/test\"]}"
                 (defRun ["--security-opt", "label=disable", "--mount", "type=tmpfs,destination=/tmp", "--volume", "/tmp/test:/tmp/test"])
-        it "run volumes"
-            $ podmanTest
+        it "run volumes" $
+            podmanTest
                 "env // { volumes = [\"nix-store:/nix\"]}"
                 (defRun ["--mount", "type=tmpfs,destination=/tmp", "--volume", "/data/nix-store:/nix"])
-        it "run home volumes"
-            $ podmanTest
+        it "run home volumes" $
+            podmanTest
                 "env // { volumes = [\"~/src:/data\"]}"
                 (defRun ["--security-opt", "label=disable", "--mount", "type=tmpfs,destination=/tmp", "--volume", "/home/user/src:/data"])
-        it "run many volumes"
-            $ podmanTest
+        it "run many volumes" $
+            podmanTest
                 "env // { volumes = [\"/home/data:/tmp/data\", \"/tmp\", \"/home/old-data:/tmp/data\"]}"
                 (defRun ["--security-opt", "label=disable", "--mount", "type=tmpfs,destination=/tmp", "--volume", "/tmp:/tmp", "--volume", "/home/data:/tmp/data"])
   where


### PR DESCRIPTION
The static build failed with:
   error: builder for '/nix/store/zvgn6rpry874jgf9yvm8kp44pb3k0gh9-podenv-0.5.0.drv' failed with exit code 1;
       last 25 log lines:
       > /nix/store/0wk2xdfq01f35k8a0mch7g3l5csdxygv-binutils-2.41/bin/ld: (.text+0x179): undefined reference to `gelf_xlatetom'
       > /nix/store/0wk2xdfq01f35k8a0mch7g3l5csdxygv-binutils-2.41/bin/ld: /nix/store/5kgfm9zk9wgzm9p19j1sihd9ir85y30q-elfutils-0.190/lib/libdw.a(dwarf_begin.o): in function `dwarf_begin':

This reverts commit c8d6737eb6b4d4cc0d2cf23505cab66b1468d59e.