### PR TITLE
Use host's ipc when x11 is enabled

### DIFF
--- a/docs/howtos/contribute.md
+++ b/docs/howtos/contribute.md
@@ -26,6 +26,11 @@ Install in your PATH:
 $ cabal install exe:podenv --installdir=$HOME/.local/bin
 ```
 
+## Golden tests
+
+The tests may fail the first time when the golden output is changed.
+Commit the changes if they are expected, then the test will succeed.
+
 ## Run tests
 
 ```ShellSession

--- a/src/Podenv/Capability.hs
+++ b/src/Podenv/Capability.hs
@@ -301,7 +301,10 @@ setX11 :: AppEnvT (Ctx.Context -> Ctx.Context)
 setX11 = do
     display <- askL envHostDisplay
     pure $
-        Ctx.directMount "/tmp/.X11-unix" . Ctx.addEnv "DISPLAY" (toText display) . Ctx.addMount "/dev/shm" Ctx.tmpfs
+        (ctxHostIPC .~ True)
+            . Ctx.directMount "/tmp/.X11-unix"
+            . Ctx.addEnv "DISPLAY" (toText display)
+            . Ctx.addMount "/dev/shm" Ctx.tmpfs
 
 setCwd :: AppEnvT (Ctx.Context -> Ctx.Context)
 setCwd = do

--- a/src/Podenv/Context.hs
+++ b/src/Podenv/Context.hs
@@ -48,6 +48,7 @@ module Podenv.Context (
     ctxSyscaps,
     ctxInteractive,
     ctxNetwork,
+    ctxHostIPC,
     ctxRO,
     ctxPrivileged,
     ctxTerminal,
@@ -90,6 +91,7 @@ data Context = Context
     , _ctxSELinux :: Bool
     , _ctxAnyUid :: UserID
     -- ^ the unique uid for this container
+    , _ctxHostIPC :: Bool
     , _ctxCommand :: [Text]
     -- ^ container command
     , _ctxWorkdir :: Maybe FilePath
@@ -127,6 +129,7 @@ defaultContext _ctxRuntime =
         , _ctxMounts = mempty
         , _ctxDevices = mempty
         , _ctxSyscaps = mempty
+        , _ctxHostIPC = False
         , _ctxRO = True
         , _ctxWorkdir = Nothing
         , _ctxInteractive = False

--- a/test/golden.txt
+++ b/test/golden.txt
@@ -125,6 +125,7 @@ Display Raw command: podman run
   --security-opt label=disable
   --user 1000
   --userns keep-id
+  --ipc=host
   --hostname default
   --network none
   --workdir /home/fedora
@@ -156,6 +157,7 @@ Vnc Raw command: podman run
   --security-opt label=disable
   --user 1000
   --userns keep-id
+  --ipc=host
   --hostname vnc
   --network none
   --workdir /home/fedora
@@ -212,6 +214,7 @@ Raw command: podman run
   --security-opt label=disable
   --user 1000
   --userns keep-id
+  --ipc=host
   --hostname vnc-viewer
   --network container:sway.vnc
   --workdir /home/fedora
@@ -227,8 +230,8 @@ Raw command: podman run
 Raw command: bwrap
   --die-with-parent
   --unshare-pid
-  --unshare-ipc
   --unshare-uts
+  --unshare-ipc
   --unshare-net
   --ro-bind /usr /usr
   --ro-bind /lib /lib
@@ -289,8 +292,8 @@ Raw command: podman run
 Raw command: bwrap
   --die-with-parent
   --unshare-pid
-  --unshare-ipc
   --unshare-uts
+  --unshare-ipc
   --unshare-net
   --ro-bind /usr /usr
   --ro-bind /lib /lib
@@ -448,8 +451,8 @@ Raw command: podman run
 Raw command: bwrap
   --die-with-parent
   --unshare-pid
-  --unshare-ipc
   --unshare-uts
+  --unshare-ipc
   --unshare-net
   --ro-bind /srv /
   --proc /proc


### PR DESCRIPTION
This change prevents rendering issues when the x11 client expects the server shm to be available.