### PR TITLE
Fix support for nix runtime with hostfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## next
 
+- fix support for hostfile with nix runtime.
+
 ## 0.8.0 (2025-07-29)
 
 - added the `devices` capability to share all the devices and support hot-pluggable devices.

--- a/src/Podenv/Capability.hs
+++ b/src/Podenv/Capability.hs
@@ -379,11 +379,15 @@ resolveFileArgs args = do
     addCommand :: Text -> Ctx.Context -> Ctx.Context
     addCommand arg = ctxCommand %~ (arg :)
     checkExist :: Text -> AppEnvT (Either Text FilePath)
-    checkExist arg = do
-        fpM <- resolveHostPath arg
-        case fpM of
-            Nothing -> pure $ Left arg
-            Just fp -> pure $ Right fp
+    checkExist arg
+        | -- Avoid adding nix path to the hostfile, this should be mounted differently
+          "/nix" `Text.isPrefixOf` arg =
+            pure $ Left arg
+        | otherwise = do
+            fpM <- resolveHostPath arg
+            case fpM of
+                Nothing -> pure $ Left arg
+                Just fp -> pure $ Right fp
 
     addFileArg :: Either Text FilePath -> Ctx.Context -> Ctx.Context
     addFileArg (Left arg) = addCommand arg


### PR DESCRIPTION
This change disable the mapping of nix command to the data folder.